### PR TITLE
performance optimization

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -30,14 +30,14 @@ end
 
 -- Return integer value for given Signal: {type=, name=}
 function get_signal_value(ent,signal)
-	if signal == nil or signal.name == nil then return(0)	end
+  if signal == nil or signal.name == nil then return(0) end
   local ent_cache = update_net_cache(ent)
 
   local signal_val = 0
 
-	if ent_cache.red_network then
-	  signal_val = signal_val + ent_cache.red_network.get_signal(signal)
-	end
+  if ent_cache.red_network then
+    signal_val = signal_val + ent_cache.red_network.get_signal(signal)
+  end
 
   if ent_cache.green_network then
     signal_val = signal_val + ent_cache.green_network.get_signal(signal)
@@ -92,8 +92,8 @@ function deployBlueprint(bp,deployer,offsetpos)
 
   local deploypos = {
     x = deployer.position.x + offsetpos.x - anchorPosition.x,
-	 y = deployer.position.y + offsetpos.y - anchorPosition.y
-	 }
+   y = deployer.position.y + offsetpos.y - anchorPosition.y
+   }
 
   bp.build_blueprint{
     surface=deployer.surface,
@@ -112,25 +112,25 @@ function copyBlueprint(inStack,outStack)
 end
 
 function charsig(c)
-	local charmap={
+  local charmap={
     ["0"]='signal-0',["1"]='signal-1',["2"]='signal-2',["3"]='signal-3',["4"]='signal-4',
     ["5"]='signal-5',["6"]='signal-6',["7"]='signal-7',["8"]='signal-8',["9"]='signal-9',
     ["A"]='signal-A',["B"]='signal-B',["C"]='signal-C',["D"]='signal-D',["E"]='signal-E',
-		["F"]='signal-F',["G"]='signal-G',["H"]='signal-H',["I"]='signal-I',["J"]='signal-J',
-		["K"]='signal-K',["L"]='signal-L',["M"]='signal-M',["N"]='signal-N',["O"]='signal-O',
-		["P"]='signal-P',["Q"]='signal-Q',["R"]='signal-R',["S"]='signal-S',["T"]='signal-T',
-		["U"]='signal-U',["V"]='signal-V',["W"]='signal-W',["X"]='signal-X',["Y"]='signal-Y',
-		["Z"]='signal-Z'
-	}
-	if charmap[c] then
-		return charmap[c]
-	else
-		return nil
-	end
+    ["F"]='signal-F',["G"]='signal-G',["H"]='signal-H',["I"]='signal-I',["J"]='signal-J',
+    ["K"]='signal-K',["L"]='signal-L',["M"]='signal-M',["N"]='signal-N',["O"]='signal-O',
+    ["P"]='signal-P',["Q"]='signal-Q',["R"]='signal-R',["S"]='signal-S',["T"]='signal-T',
+    ["U"]='signal-U',["V"]='signal-V',["W"]='signal-W',["X"]='signal-X',["Y"]='signal-Y',
+    ["Z"]='signal-Z'
+  }
+  if charmap[c] then
+    return charmap[c]
+  else
+    return nil
+  end
 end
 
 function sigchar(c)
-	local charmap={
+  local charmap={
     ['signal-0']='0',['signal-1']='1',['signal-2']='2',['signal-3']='3',['signal-4']='4',
     ['signal-5']='5',['signal-6']='6',['signal-7']='7',['signal-8']='8',['signal-9']='9',
     ['signal-A']='A',['signal-B']='B',['signal-C']='C',['signal-D']='D',
@@ -144,12 +144,12 @@ function sigchar(c)
     ['signal-blue']='',
     ['signal-white']='',
 
-	}
-	if charmap[c] then
-		return charmap[c]
-	else
-		return ' '
-	end
+  }
+  if charmap[c] then
+    return charmap[c]
+  else
+    return ' '
+  end
 end
 
 

--- a/deployer.lua
+++ b/deployer.lua
@@ -1,17 +1,19 @@
 local function onTickDeployer(deployer)
+
   local deployPrint = get_signal_value(deployer,{name="construction-robot",type="item"})
   local deconstructArea = get_signal_value(deployer,{name="deconstruction-planner",type="item"})
-  local X = get_signal_value(deployer,{name="signal-X",type="virtual"})
-  local Y = get_signal_value(deployer,{name="signal-Y",type="virtual"})
-  local W = get_signal_value(deployer,{name="signal-W",type="virtual"})
-  local H = get_signal_value(deployer,{name="signal-H",type="virtual"})
 
-  -- Check chest inventory for blueprint
-  local deployerInventory = deployer.get_inventory(defines.inventory.chest)
-  local deployerItemStack = deployerInventory[1]
-
+  -- deployement-related actions
   if deployPrint > 0 then
+    -- Check chest inventory for blueprint
+    local deployerInventory = deployer.get_inventory(defines.inventory.chest)
+    local deployerItemStack = deployerInventory[1]
+
     if not deployerItemStack.valid_for_read then return end
+
+    local X = get_signal_value(deployer,{name="signal-X",type="virtual"})
+    local Y = get_signal_value(deployer,{name="signal-Y",type="virtual"})
+
     if deployerItemStack.name == "blueprint" then
       deployBlueprint(deployerItemStack,deployer,{x=X,y=Y})
     elseif deployerItemStack.name == "blueprint-book" then
@@ -23,33 +25,55 @@ local function onTickDeployer(deployer)
         deployBlueprint(bookInv[deployPrint],deployer,{x=X,y=Y})
       end
     end
-  elseif deconstructArea == -1 then -- decon=-1 Deconstruct Area
-    deployer.surface.deconstruct_area{
-	   area={
-	     {deployer.position.x+X-(W/2),deployer.position.y+Y-(H/2)},
-		  {deployer.position.x+X+(W/2),deployer.position.y+Y+(H/2)}
-		  },
-		force=deployer.force}
-    deployer.cancel_deconstruction(deployer.force) -- Don't deconstruct myself in an area order
-  elseif deconstructArea == -2 then -- decon=-2 Deconstruct Self
-    deployer.order_deconstruction(deployer.force)
-  elseif deconstructArea == 1 then -- decon=1 Cancel Area
-    deployer.surface.cancel_deconstruct_area{
-	   area={
-       {deployer.position.x+X-(W/2),deployer.position.y+Y-(H/2)},
-		  {deployer.position.x+X+(W/2),deployer.position.y+Y+(H/2)}
-		  },
-		force=deployer.force}
+    
+  -- deconstruction-related actions
+  else
+    local X,Y,W,H=0,0,0,0
+    if deconstructArea == -1 or deconstructArea == 1 then
+      local signal_groups = get_all_signals(deployer)
+      for _,sig_group in pairs(signal_groups) do
+        for _,sig in pairs(sig_group) do
+          if sig.signal.name=="signal-X" then
+            X = X+sig.count
+          elseif sig.signal.name=="signal-H" then
+            H = H+sig.count
+          elseif sig.signal.name=="signal-W" then
+            W = W+sig.count
+          elseif sig.signal.name=="signal-Y" then
+            Y = Y+sig.count
+          end
+        end
+      end
+    end
+
+    if deconstructArea == -1 then -- decon=-1 Deconstruct Area
+      deployer.surface.deconstruct_area{
+  	   area={
+  	     {deployer.position.x+X-(W/2),deployer.position.y+Y-(H/2)},
+  		  {deployer.position.x+X+(W/2),deployer.position.y+Y+(H/2)}
+  		  },
+  		force=deployer.force}
+      deployer.cancel_deconstruction(deployer.force) -- Don't deconstruct myself in an area order
+    elseif deconstructArea == -2 then -- decon=-2 Deconstruct Self
+      deployer.order_deconstruction(deployer.force)
+    elseif deconstructArea == 1 then -- decon=1 Cancel Area
+      deployer.surface.cancel_deconstruct_area{
+  	   area={
+         {deployer.position.x+X-(W/2),deployer.position.y+Y-(H/2)},
+  		  {deployer.position.x+X+(W/2),deployer.position.y+Y+(H/2)}
+  		  },
+  		force=deployer.force}
+    end
   end
 end
 
 local function onTickDeployers(event)
   if global.deployers then
     for _,deployer in pairs(global.deployers) do
-  		if deployer.valid and deployer.name == "blueprint-deployer" then
-  		  onTickDeployer(deployer)
+      if deployer.valid and deployer.name == "blueprint-deployer" then
+        onTickDeployer(deployer)
   		else
-  		  global.deployers[_]=nil
+        global.deployers[_]=nil
   		end
     end
   end

--- a/deployer.lua
+++ b/deployer.lua
@@ -48,21 +48,21 @@ local function onTickDeployer(deployer)
 
     if deconstructArea == -1 then -- decon=-1 Deconstruct Area
       deployer.surface.deconstruct_area{
-  	   area={
-  	     {deployer.position.x+X-(W/2),deployer.position.y+Y-(H/2)},
-  		  {deployer.position.x+X+(W/2),deployer.position.y+Y+(H/2)}
-  		  },
-  		force=deployer.force}
+       area={
+         {deployer.position.x+X-(W/2),deployer.position.y+Y-(H/2)},
+        {deployer.position.x+X+(W/2),deployer.position.y+Y+(H/2)}
+        },
+      force=deployer.force}
       deployer.cancel_deconstruction(deployer.force) -- Don't deconstruct myself in an area order
     elseif deconstructArea == -2 then -- decon=-2 Deconstruct Self
       deployer.order_deconstruction(deployer.force)
     elseif deconstructArea == 1 then -- decon=1 Cancel Area
       deployer.surface.cancel_deconstruct_area{
-  	   area={
+       area={
          {deployer.position.x+X-(W/2),deployer.position.y+Y-(H/2)},
-  		  {deployer.position.x+X+(W/2),deployer.position.y+Y+(H/2)}
-  		  },
-  		force=deployer.force}
+        {deployer.position.x+X+(W/2),deployer.position.y+Y+(H/2)}
+        },
+      force=deployer.force}
     end
   end
 end
@@ -72,9 +72,9 @@ local function onTickDeployers(event)
     for _,deployer in pairs(global.deployers) do
       if deployer.valid and deployer.name == "blueprint-deployer" then
         onTickDeployer(deployer)
-  		else
+      else
         global.deployers[_]=nil
-  		end
+      end
     end
   end
 end


### PR DESCRIPTION
Changes:

- Only check each circuit network a maximum of once per tick
- Never call get_circuit_network if the last one is still valid
- Never call get_control_behavior
- When getting several signals, it's faster to iterate over network.signals instead of calling network.get_signal() many times.

Results:
- 2-3x performance boost in static scenarios with many deployers getting constant signals
- 3-10x boost on one testcase with greygoo, 12-30x boost on another testcase
- fixes mysterious issue of spikes up to 60ms per update. Haven't ever seen it ever exceed 5 ms on my computer now.